### PR TITLE
Cambiar código de error 400 a 401 en controlador inicio sesión.

### DIFF
--- a/backend/src/main/java/com/camyo/backend/auth/AuthController.java
+++ b/backend/src/main/java/com/camyo/backend/auth/AuthController.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -64,7 +65,7 @@ public class AuthController {
     @Operation(summary = "Iniciar sesión", description = "Autentica a un usuario y devuelve un token JWT.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "Autenticación exitosa"),
-        @ApiResponse(responseCode = "400", description = "Credenciales incorrectas")
+        @ApiResponse(responseCode = "401", description = "Credenciales incorrectas")
     })
 	@PostMapping("/signin")
 	public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
@@ -82,7 +83,7 @@ public class AuthController {
 	
 			return ResponseEntity.ok().body(new JwtResponse(jwt, userDetails.getId(), userDetails.getUsername(), roles));
 		} catch (BadCredentialsException exception) {
-			return ResponseEntity.badRequest().body("Credenciales incorrectas!");
+			return new ResponseEntity<String>("Credenciales incorrectas!", HttpStatus.UNAUTHORIZED);
 		}
 	}
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated HTTP error code from 400 to 401 for incorrect credentials.

- Adjusted response entity to use `HttpStatus.UNAUTHORIZED` for authentication errors.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthController.java</strong><dd><code>Update error code and response entity in AuthController</code>&nbsp; &nbsp; </dd></summary>
<hr>

backend/src/main/java/com/camyo/backend/auth/AuthController.java

<li>Changed API response code from 400 to 401 for incorrect credentials.<br> <li> Updated response entity to use <code>HttpStatus.UNAUTHORIZED</code>.


</details>


  </td>
  <td><a href="https://github.com/Camyo-ISPP/CamyoApp/pull/59/files#diff-abf962d964f6ebe98a55c9cfafad012186268989eb201c14cca37921b50c48b7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>