### PR TITLE
Añadir más tests unitarios y de integración para las funciones de oferta

### DIFF
--- a/backend/src/test/java/com/camyo/backend/Oferta/CargaServiceTest.java
+++ b/backend/src/test/java/com/camyo/backend/Oferta/CargaServiceTest.java
@@ -1,0 +1,51 @@
+package com.camyo.backend.Oferta;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.camyo.backend.oferta.Carga;
+import com.camyo.backend.oferta.CargaRepository;
+import com.camyo.backend.oferta.CargaService;
+
+
+public class CargaServiceTest {
+
+    @Mock
+    private CargaRepository cargaRepository;
+
+    @InjectMocks
+    private CargaService cargaService;
+
+    private Carga carga;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        carga = new Carga();
+        carga.setId(1);
+        carga.setMercancia("Electrodomésticos");
+        carga.setPeso(1200.0);
+        carga.setOrigen("Sevilla");
+        carga.setDestino("Madrid");
+        carga.setDistancia(500);
+        carga.setInicio(LocalDate.now());
+        carga.setFinMinimo(LocalDate.now().plusDays(1));
+        carga.setFinMaximo(LocalDate.now().plusDays(3));
+    }
+
+    @Test
+    void debeGuardarCarga() {
+        when(cargaRepository.save(carga)).thenReturn(carga);
+        Carga resultado = cargaService.guardarCarga(carga);
+        assertEquals(carga, resultado);
+        verify(cargaRepository, times(1)).save(carga);
+    }
+}

--- a/backend/src/test/java/com/camyo/backend/Oferta/OfertaControllerTests.java
+++ b/backend/src/test/java/com/camyo/backend/Oferta/OfertaControllerTests.java
@@ -181,4 +181,43 @@ public class OfertaControllerTests {
         mockMvc.perform(put(BASE_URL + "/1/rechazar/1"))
             .andExpect(status().isOk());
     }
+
+    @Test
+    void debeObtenerTrabajoDeOferta() throws Exception {
+        when(ofertaService.obtenerTrabajo(1)).thenReturn(trabajo);
+        mockMvc.perform(get(BASE_URL + "/1/trabajo"))
+            .andExpect(status().isOk());
+    }
+    @Test
+    void debeObtenerCargaDeOferta() throws Exception {
+        when(ofertaService.obtenerCarga(1)).thenReturn(carga);
+        mockMvc.perform(get(BASE_URL + "/1/carga"))
+            .andExpect(status().isOk());
+    }
+    @Test
+    void debeObtenerOfertasPorCamionero() throws Exception {
+        when(ofertaService.obtenerOfertasPorCamionero(1)).thenReturn(List.of(List.of(oferta1)));
+        mockMvc.perform(get(BASE_URL + "/camionero/1"))
+            .andExpect(status().isOk());
+    }
+    @Test
+    void debeObtenerOfertasPorEmpresa() throws Exception {
+        when(ofertaService.obtenerOfertasPorEmpresa(1)).thenReturn(List.of(oferta1));
+        mockMvc.perform(get(BASE_URL + "/empresa/1"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void debePatrocinarOferta() throws Exception {
+        when(ofertaService.patrocinarOferta(1)).thenReturn(oferta1);
+        mockMvc.perform(put(BASE_URL + "/1/patrocinar"))
+            .andExpect(status().isOk());
+    }    
+    @Test
+    void debeDesactivarPatrocinio() throws Exception {
+        doNothing().when(ofertaService).desactivarPatrocinio(1);
+        mockMvc.perform(put(BASE_URL + "/1/desactivar-patrocinio"))
+            .andExpect(status().isOk());
+    }
+
 }

--- a/backend/src/test/java/com/camyo/backend/Oferta/OfertaServiceTests.java
+++ b/backend/src/test/java/com/camyo/backend/Oferta/OfertaServiceTests.java
@@ -57,7 +57,6 @@ public class OfertaServiceTests {
         usuario = new Usuario();
         usuario.setId(10);
 
-        // Para que coincida con el if: user.hasAuthority("EMPRESA")
         Authorities roleEmpresa = new Authorities();
         roleEmpresa.setAuthority("EMPRESA");
         usuario.setAuthority(roleEmpresa);
@@ -76,16 +75,13 @@ public class OfertaServiceTests {
         camionero = new Camionero();
         camionero.setId(1);
 
-        // Mock de usuario autenticado con userID=10
         UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
         when(userDetails.getId()).thenReturn(10);
         SecurityContextHolder.getContext().setAuthentication(
             new UsernamePasswordAuthenticationToken(userDetails, null, new ArrayList<>())
         );
 
-        // Cuando se pida usuario 10, devolvemos este "usuario"
         when(usuarioRepository.findById(10)).thenReturn(Optional.of(usuario));
-        // Cuando se pida empresa por usuario 10, devolvemos la "empresa" (id=1)
         when(empresaRepository.obtenerPorUsuario(10)).thenReturn(Optional.of(empresa));
     }
 
@@ -155,7 +151,6 @@ public class OfertaServiceTests {
 
         Oferta result = ofertaService.asignarOferta(1, 1);
         assertEquals(camionero, result.getCamionero());
-        // Los demás aplicados pasan a rechazados:
         assertTrue(result.getRechazados().containsAll(oferta.getAplicados()));
     }
 
@@ -217,13 +212,11 @@ public class OfertaServiceTests {
         assertNotNull(result);
     }
 
-    // ========================== Patrocinio Tests ==========================
 
     @Test
     void debePatrocinarOfertaConPlanGratisYDisponible() {
         when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
 
-        // ¡Importante!: Usa el ID de la empresa (1), no el del usuario (10)
         when(suscripcionService.obtenerNivelSuscripcion(empresa.getId()))
             .thenReturn(PlanNivel.GRATIS);
 
@@ -249,7 +242,6 @@ public class OfertaServiceTests {
 
     @Test
     void noDebePatrocinarOfertaSiSinPermiso() {
-        // Cambiamos la empresa de la oferta => ID distinto
         Empresa otraEmpresa = new Empresa(); 
         otraEmpresa.setId(99);
         oferta.setEmpresa(otraEmpresa);
@@ -266,7 +258,6 @@ public class OfertaServiceTests {
     void noDebePatrocinarOfertaSiSuperaLimiteGratis() {
         when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
 
-        // Usa empresaId=1, de lo contrario suscripcionService devolverá null
         when(suscripcionService.obtenerNivelSuscripcion(empresa.getId()))
             .thenReturn(PlanNivel.GRATIS);
 

--- a/backend/src/test/java/com/camyo/backend/Oferta/OfertaServiceTests.java
+++ b/backend/src/test/java/com/camyo/backend/Oferta/OfertaServiceTests.java
@@ -2,63 +2,91 @@ package com.camyo.backend.Oferta;
 
 import com.camyo.backend.camionero.Camionero;
 import com.camyo.backend.camionero.CamioneroRepository;
+import com.camyo.backend.configuration.services.UserDetailsImpl;
 import com.camyo.backend.empresa.Empresa;
 import com.camyo.backend.empresa.EmpresaRepository;
 import com.camyo.backend.exceptions.ResourceNotFoundException;
 import com.camyo.backend.oferta.*;
+import com.camyo.backend.suscripcion.PlanNivel;
+import com.camyo.backend.suscripcion.SuscripcionService;
+import com.camyo.backend.usuario.Authorities;
+import com.camyo.backend.usuario.Usuario;
+import com.camyo.backend.usuario.UsuarioRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.time.LocalDateTime;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class OfertaServiceTests {
 
-    @Mock
-    private OfertaRepository ofertaRepository;
+    @Mock private OfertaRepository ofertaRepository;
+    @Mock private CargaRepository cargaRepository;
+    @Mock private TrabajoRepository trabajoRepository;
+    @Mock private CamioneroRepository camioneroRepository;
+    @Mock private EmpresaRepository empresaRepository;
+    @Mock private UsuarioRepository usuarioRepository;
+    @Mock private SuscripcionService suscripcionService;
 
-    @Mock
-    private CargaRepository cargaRepository;
-
-    @Mock
-    private TrabajoRepository trabajoRepository;
-
-    @Mock
-    private CamioneroRepository camioneroRepository;
-
-    @Mock
-    private EmpresaRepository empresaRepository;
-
-    @InjectMocks
+    @InjectMocks 
     private OfertaService ofertaService;
 
     private Oferta oferta;
+    private Empresa empresa;
     private Camionero camionero;
+    private Usuario usuario;
 
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
 
-        Empresa empresa = new Empresa();
+        usuario = new Usuario();
+        usuario.setId(10);
+
+        // Para que coincida con el if: user.hasAuthority("EMPRESA")
+        Authorities roleEmpresa = new Authorities();
+        roleEmpresa.setAuthority("EMPRESA");
+        usuario.setAuthority(roleEmpresa);
+
+        empresa = new Empresa();
         empresa.setId(1);
+        empresa.setUsuario(usuario);
 
         oferta = new Oferta();
         oferta.setId(1);
-        oferta.setTitulo("Test Oferta");
-        oferta.setFechaPublicacion(LocalDateTime.now());
         oferta.setEmpresa(empresa);
+        oferta.setPromoted(false);
         oferta.setAplicados(new HashSet<>());
         oferta.setRechazados(new HashSet<>());
-        oferta.setEstado(OfertaEstado.ABIERTA);
 
         camionero = new Camionero();
         camionero.setId(1);
+
+        // Mock de usuario autenticado con userID=10
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getId()).thenReturn(10);
+        SecurityContextHolder.getContext().setAuthentication(
+            new UsernamePasswordAuthenticationToken(userDetails, null, new ArrayList<>())
+        );
+
+        // Cuando se pida usuario 10, devolvemos este "usuario"
+        when(usuarioRepository.findById(10)).thenReturn(Optional.of(usuario));
+        // Cuando se pida empresa por usuario 10, devolvemos la "empresa" (id=1)
+        when(empresaRepository.obtenerPorUsuario(10)).thenReturn(Optional.of(empresa));
     }
 
     @Test
@@ -75,50 +103,6 @@ public class OfertaServiceTests {
     }
 
     @Test
-    void debeAplicarOferta() {
-        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
-        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
-        when(ofertaRepository.save(any(Oferta.class))).thenReturn(oferta);
-
-        Oferta result = ofertaService.aplicarOferta(1, 1);
-        assertTrue(result.getAplicados().contains(camionero));
-    }
-
-    @Test
-    void debeDesaplicarOferta() {
-        oferta.getAplicados().add(camionero);
-        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
-        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
-        when(ofertaRepository.save(any(Oferta.class))).thenReturn(oferta);
-
-        Oferta result = ofertaService.desaplicarOferta(1, 1);
-        assertFalse(result.getAplicados().contains(camionero));
-    }
-
-    @Test
-    void debeRechazarOferta() {
-        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
-        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
-        when(ofertaRepository.save(any(Oferta.class))).thenReturn(oferta);
-
-        Oferta result = ofertaService.rechazarOferta(1, 1);
-        assertTrue(result.getRechazados().contains(camionero));
-    }
-
-    @Test
-    void debeAsignarOferta() {
-        oferta.getAplicados().add(camionero);
-        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
-        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
-        when(ofertaRepository.save(any(Oferta.class))).thenReturn(oferta);
-
-        Oferta result = ofertaService.asignarOferta(1, 1);
-        assertEquals(camionero, result.getCamionero());
-        assertTrue(result.getRechazados().containsAll(oferta.getAplicados()));
-        assertEquals(OfertaEstado.CERRADA, result.getEstado());
-    }
-
-    @Test
     void debeGuardarOferta() {
         when(ofertaRepository.save(oferta)).thenReturn(oferta);
         Oferta result = ofertaService.guardarOferta(oferta);
@@ -129,5 +113,205 @@ public class OfertaServiceTests {
     void debeEliminarOferta() {
         doNothing().when(ofertaRepository).deleteById(1);
         assertDoesNotThrow(() -> ofertaService.eliminarOferta(1));
+    }
+
+    @Test
+    void debeAplicarOferta() {
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
+        when(ofertaRepository.save(any())).thenReturn(oferta);
+
+        Oferta result = ofertaService.aplicarOferta(1, 1);
+        assertTrue(result.getAplicados().contains(camionero));
+    }
+
+    @Test
+    void debeDesaplicarOferta() {
+        oferta.getAplicados().add(camionero);
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
+        when(ofertaRepository.save(any())).thenReturn(oferta);
+
+        Oferta result = ofertaService.desaplicarOferta(1, 1);
+        assertFalse(result.getAplicados().contains(camionero));
+    }
+
+    @Test
+    void debeRechazarOferta() {
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
+        when(ofertaRepository.save(any())).thenReturn(oferta);
+
+        Oferta result = ofertaService.rechazarOferta(1, 1);
+        assertTrue(result.getRechazados().contains(camionero));
+    }
+
+    @Test
+    void debeAsignarOferta() {
+        oferta.getAplicados().add(camionero);
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
+        when(ofertaRepository.save(any())).thenReturn(oferta);
+
+        Oferta result = ofertaService.asignarOferta(1, 1);
+        assertEquals(camionero, result.getCamionero());
+        // Los demás aplicados pasan a rechazados:
+        assertTrue(result.getRechazados().containsAll(oferta.getAplicados()));
+    }
+
+    @Test
+    void debeObtenerOfertasPorEmpresa() {
+        when(empresaRepository.findById(1)).thenReturn(Optional.of(empresa));
+        when(ofertaRepository.encontrarOfertasPorEmpresa(1)).thenReturn(List.of(oferta));
+
+        List<Oferta> result = ofertaService.obtenerOfertasPorEmpresa(1);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void debeObtenerOfertasPorCamionero() {
+        when(camioneroRepository.findById(1)).thenReturn(Optional.of(camionero));
+        when(ofertaRepository.encontrarAplicadas(1)).thenReturn(List.of(oferta));
+        when(ofertaRepository.encontrarRechazadas(1)).thenReturn(List.of());
+        when(ofertaRepository.encontrarAsignadas(1)).thenReturn(List.of());
+
+        List<List<Oferta>> result = ofertaService.obtenerOfertasPorCamionero(1);
+        assertEquals(3, result.size());
+    }
+
+    @Test
+    void debeObtenerUltimas10Ofertas() {
+        when(ofertaRepository.findTopByOrderByFechaPublicacionDesc()).thenReturn(List.of(oferta));
+        List<Oferta> result = ofertaService.obtenerUltimas10Ofertas();
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    void debeObtenerCargaYTrabajo() {
+        Carga carga = new Carga(); 
+        carga.setId(1);
+        Trabajo trabajo = new Trabajo(); 
+        trabajo.setId(1);
+
+        when(ofertaRepository.encontrarCargaPorOferta(1)).thenReturn(carga);
+        when(ofertaRepository.encontrarTrabajoPorOferta(1)).thenReturn(trabajo);
+
+        assertEquals(carga, ofertaService.obtenerCarga(1));
+        assertEquals(trabajo, ofertaService.obtenerTrabajo(1));
+    }
+
+    @Test
+    void debeModificarOferta() {
+        Oferta modificada = new Oferta();
+        modificada.setTitulo("Modificada");
+
+        Empresa empresaNueva = new Empresa(); 
+        empresaNueva.setId(2);
+        modificada.setEmpresa(empresaNueva);
+
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+        when(empresaRepository.findById(2)).thenReturn(Optional.of(empresaNueva));
+        when(ofertaRepository.save(any())).thenReturn(oferta);
+
+        Oferta result = ofertaService.modificarOferta(modificada, 1);
+        assertNotNull(result);
+    }
+
+    // ========================== Patrocinio Tests ==========================
+
+    @Test
+    void debePatrocinarOfertaConPlanGratisYDisponible() {
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+
+        // ¡Importante!: Usa el ID de la empresa (1), no el del usuario (10)
+        when(suscripcionService.obtenerNivelSuscripcion(empresa.getId()))
+            .thenReturn(PlanNivel.GRATIS);
+
+        when(ofertaRepository.countByEmpresaIdPromotedTrue(empresa.getId()))
+            .thenReturn(0);
+
+        when(ofertaRepository.save(any())).thenReturn(oferta);
+
+        Oferta resultado = ofertaService.patrocinarOferta(1);
+        assertTrue(resultado.getPromoted());
+    }
+
+    @Test
+    void noDebePatrocinarOfertaSiYaPromocionada() {
+        oferta.setPromoted(true);
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> ofertaService.patrocinarOferta(1)
+        );
+        assertEquals("Esta oferta ya está patrocinada actualmente.", ex.getMessage());
+    }
+
+    @Test
+    void noDebePatrocinarOfertaSiSinPermiso() {
+        // Cambiamos la empresa de la oferta => ID distinto
+        Empresa otraEmpresa = new Empresa(); 
+        otraEmpresa.setId(99);
+        oferta.setEmpresa(otraEmpresa);
+
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+        
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> ofertaService.patrocinarOferta(1)
+        );
+        assertEquals("No tienes permiso para patrocinar esta oferta.", ex.getMessage());
+    }
+
+    @Test
+    void noDebePatrocinarOfertaSiSuperaLimiteGratis() {
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+
+        // Usa empresaId=1, de lo contrario suscripcionService devolverá null
+        when(suscripcionService.obtenerNivelSuscripcion(empresa.getId()))
+            .thenReturn(PlanNivel.GRATIS);
+
+        when(ofertaRepository.countByEmpresaIdPromotedTrue(empresa.getId()))
+            .thenReturn(1);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> ofertaService.patrocinarOferta(1)
+        );
+        assertEquals("El plan Gratis solo permite patrocinar 1 oferta.", ex.getMessage());
+    }
+
+    @Test
+    void debeDesactivarPatrocinioCorrectamente() {
+        oferta.setPromoted(true);
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+        when(ofertaRepository.save(any())).thenReturn(oferta);
+
+        assertDoesNotThrow(() -> ofertaService.desactivarPatrocinio(1));
+        assertFalse(oferta.getPromoted());
+    }
+
+    @Test
+    void noDebeDesactivarPatrocinioSinPermiso() {
+        Empresa otraEmpresa = new Empresa(); 
+        otraEmpresa.setId(99);
+        oferta.setEmpresa(otraEmpresa);
+        oferta.setPromoted(true);
+
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> ofertaService.desactivarPatrocinio(1)
+        );
+        assertEquals("No tienes permiso para desactivar esta oferta.", ex.getMessage());
+    }
+
+    @Test
+    void noDebeDesactivarPatrocinioSiNoEstaActivo() {
+        oferta.setPromoted(false);
+        when(ofertaRepository.findById(1)).thenReturn(Optional.of(oferta));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> ofertaService.desactivarPatrocinio(1)
+        );
+        assertEquals("Esta oferta no está patrocinada.", ex.getMessage());
     }
 }

--- a/backend/src/test/java/com/camyo/backend/Oferta/TrabajoServiceTests.java
+++ b/backend/src/test/java/com/camyo/backend/Oferta/TrabajoServiceTests.java
@@ -1,0 +1,41 @@
+package com.camyo.backend.Oferta;
+
+import com.camyo.backend.oferta.Trabajo;
+import com.camyo.backend.oferta.TrabajoRepository;
+import com.camyo.backend.oferta.TrabajoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class TrabajoServiceTests {
+
+    @Mock
+    private TrabajoRepository trabajoRepository;
+
+    @InjectMocks
+    private TrabajoService trabajoService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void debeGuardarTrabajo() {
+        Trabajo trabajo = new Trabajo();
+        trabajo.setFechaIncorporacion(LocalDate.now());
+        when(trabajoRepository.save(trabajo)).thenReturn(trabajo);
+
+        Trabajo resultado = trabajoService.guardarTrabajo(trabajo);
+
+        assertEquals(trabajo, resultado);
+        verify(trabajoRepository, times(1)).save(trabajo);
+    }
+}


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Added extensive unit tests for `CargaService`, `OfertaController`, `OfertaService`, and `TrabajoService`.

- Enhanced test coverage for offer-related functionalities, including sponsorship and permissions.

- Introduced new test cases for edge scenarios like unauthorized actions and subscription limits.

- Improved mocking and setup for repository and service dependencies in tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CargaServiceTest.java</strong><dd><code>Add unit tests for `CargaService`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/test/java/com/camyo/backend/Oferta/CargaServiceTest.java

<li>Added unit tests for <code>CargaService</code>.<br> <li> Tested saving a <code>Carga</code> entity with mocked repository.<br> <li> Verified repository interactions during save operation.


</details>


  </td>
  <td><a href="https://github.com/Camyo-ISPP/CamyoApp/pull/219/files#diff-46da707b5f707c2e587bb74d08bd977e41c7cfa88b3f6a05ce3188838d4505c0">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OfertaControllerTests.java</strong><dd><code>Extend test coverage for `OfertaController`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/test/java/com/camyo/backend/Oferta/OfertaControllerTests.java

<li>Added new test cases for <code>OfertaController</code>.<br> <li> Covered endpoints for sponsorship, load retrieval, and company/driver <br>offers.<br> <li> Verified HTTP status codes and service interactions.


</details>


  </td>
  <td><a href="https://github.com/Camyo-ISPP/CamyoApp/pull/219/files#diff-652ba4d9085a3e33bb027655acce9acd605aab87807b484f0a0c4146872493ae">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OfertaServiceTests.java</strong><dd><code>Add comprehensive tests for `OfertaService`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/test/java/com/camyo/backend/Oferta/OfertaServiceTests.java

<li>Added extensive test cases for <code>OfertaService</code>.<br> <li> Covered scenarios for sponsorship, permissions, and subscription <br>limits.<br> <li> Enhanced mocking for repositories and security context.<br> <li> Tested edge cases like unauthorized actions and invalid states.


</details>


  </td>
  <td><a href="https://github.com/Camyo-ISPP/CamyoApp/pull/219/files#diff-9f530ecf06421a0fa49271397e3fac6850432b1acc5d3ee903c9db06ddc4e1ce">+207/-32</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TrabajoServiceTests.java</strong><dd><code>Add unit tests for `TrabajoService`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/src/test/java/com/camyo/backend/Oferta/TrabajoServiceTests.java

<li>Added unit tests for <code>TrabajoService</code>.<br> <li> Tested saving a <code>Trabajo</code> entity with mocked repository.<br> <li> Verified repository interactions during save operation.


</details>


  </td>
  <td><a href="https://github.com/Camyo-ISPP/CamyoApp/pull/219/files#diff-01a1a92bd516d8ef4951b357306f1eb829a92bd53250d879f1d8dc8f83ac5fb6">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>